### PR TITLE
feat: Implement server-side logic for quote management

### DIFF
--- a/app/admin/QuoteList.tsx
+++ b/app/admin/QuoteList.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { toast } from 'sonner';
-import { initiateOnboardingAction } from './actions';
-import { SubmitButton } from '@/components/SubmitButton';
+import { onboardQuoteAction, rejectQuoteAction } from './actions';
+import { Button } from '@/components/Button';
 import { Input } from '@/components/Input';
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import { EmptyState } from '@/components/EmptyState';
 import { IconQuote } from '@/components/icons/IconQuote';
+import { SubmitButton } from '@/components/SubmitButton';
 
 type Quote = {
   id: number;
@@ -18,27 +19,38 @@ type Quote = {
 };
 
 function QuoteItem({ quote }: { quote: Quote }) {
-  const [price, setPrice] = useState(quote.price || '');
+  const [isRejecting, startRejectTransition] = useTransition();
+  // Price is in Euros for the input, converted from cents
+  const [price, setPrice] = useState(quote.price ? (quote.price / 100).toString() : '');
 
-  const handleFormAction = async (formData: FormData) => {
-    formData.append('price', price.toString());
+  const handleReject = () => {
+    startRejectTransition(async () => {
+      const result = await rejectQuoteAction(quote.id);
+      if (result?.error) {
+        toast.error("Erreur", { description: result.error });
+      } else {
+        toast.success("Succès", { description: "Devis rejeté." });
+      }
+    });
+  };
 
-    const result = await initiateOnboardingAction(formData);
+  // Wrapper for form action to handle transition
+  const handleOnboardSubmit = async (formData: FormData) => {
+    const priceValue = parseFloat(formData.get('price') as string);
+    const result = await onboardQuoteAction(quote.id, priceValue);
     if (result?.error) {
       toast.error("Erreur", { description: result.error });
     } else {
-      toast.success("Succès", { description: result.message });
+      toast.success("Succès", { description: "Processus d'onboarding lancé." });
     }
   };
-
-  const isOnboardingStarted = quote.status !== 'nouveau';
 
   return (
     <li className="p-4 bg-deep-space-blue rounded-md border border-slate-dark/30 flex flex-col sm:flex-row justify-between sm:items-center gap-4">
       <div className="flex-grow">
         <p className="font-semibold text-slate-light">{quote.client_email}</p>
         <p className="text-sm text-slate-dark">
-          Reçu le: {new Date(quote.created_at).toLocaleDateString('fr-FR')} | Statut: <span className="font-semibold text-kinetic-cyan">{quote.status}</span>
+          Reçu le: {new Date(quote.created_at).toLocaleDateString('fr-FR')}
         </p>
         <details className="mt-2 text-xs">
           <summary className="cursor-pointer text-kinetic-cyan hover:underline">Voir les détails</summary>
@@ -48,23 +60,31 @@ function QuoteItem({ quote }: { quote: Quote }) {
         </details>
       </div>
 
-      {!isOnboardingStarted && (
-        <form action={handleFormAction} className="flex items-center gap-2 self-end sm:self-center">
-          <input type="hidden" name="quoteId" value={quote.id} />
-          <Input
-            type="number"
-            name="priceInput"
-            placeholder="Prix (en €)"
-            className="w-32 h-9"
-            value={price}
-            onChange={(e) => setPrice(e.target.value)}
-            required
-          />
-          <SubmitButton size="sm" loadingText="Envoi...">
-            Lancer l'Onboarding
-          </SubmitButton>
+      <div className="flex items-center gap-2 self-end sm:self-center">
+        <form action={handleOnboardSubmit} className="flex items-center gap-2">
+            <Input
+                type="number"
+                name="price"
+                placeholder="Prix (€)"
+                className="w-32 h-9"
+                value={price}
+                onChange={(e) => setPrice(e.target.value)}
+                step="0.01"
+                required
+            />
+            <SubmitButton size="sm" loadingText="Lancement...">
+                Lancer l'Onboarding
+            </SubmitButton>
         </form>
-      )}
+        <Button
+          onClick={handleReject}
+          disabled={isRejecting}
+          size="sm"
+          variant="destructive"
+        >
+          {isRejecting ? "Rejet..." : "Rejeter"}
+        </Button>
+      </div>
     </li>
   );
 }

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -5,6 +5,7 @@ import { createServer } from '@/lib/supabase-client';
 import { revalidatePath } from 'next/cache';
 import { novu } from '@/lib/novu';
 import { sendContractForSignature } from '@/lib/docuseal';
+import lagoClient from '@/lib/lago';
 
 /**
  * Action serveur pour convertir un devis en projet.
@@ -114,5 +115,114 @@ export async function initiateOnboardingAction(formData: FormData) {
   } catch (error: any) {
     console.error("Erreur lors de l'initiation de l'onboarding:", error);
     return { success: false, error: error.message };
+  }
+}
+
+
+/**
+ * Action serveur pour lancer l'onboarding d'un devis.
+ * Envoie le contrat via DocuSeal, crée la facture initiale via Lago,
+ * et met à jour le statut du devis.
+ */
+export async function onboardQuoteAction(quoteId: number, price: number) {
+  if (!quoteId) {
+    return { success: false, error: 'ID du devis manquant.' };
+  }
+  if (!price || price <= 0) {
+    return { success: false, error: 'Le prix fourni est invalide.' };
+  }
+
+  const cookieStore = cookies();
+  const supabase = createServer(cookieStore);
+  const templateId = process.env.DOCUSEAL_TEMPLATE_ID;
+
+  if (!templateId) {
+    return { success: false, error: "L'ID du modèle de contrat DocuSeal (DOCUSEAL_TEMPLATE_ID) n'est pas configuré." };
+  }
+
+  try {
+    // 1. Mettre à jour le prix du devis (en centimes) et récupérer les infos
+    const priceInCents = Math.round(price * 100);
+    const { data: quote, error: quoteError } = await supabase
+      .from('quotes')
+      .update({ price: priceInCents })
+      .eq('id', quoteId)
+      .select('id, client_email, user_id')
+      .single();
+
+    if (quoteError || !quote) {
+      throw new Error(`Devis non trouvé ou erreur lors de la mise à jour du prix pour l'ID: ${quoteId}`);
+    }
+
+    // 2. Envoyer le contrat via DocuSeal
+    const docusealResponse = await sendContractForSignature(quote.client_email, Number(templateId));
+
+    // 3. Créer une facture unique sur Lago
+    await lagoClient.invoices.createInvoice({
+      invoice: {
+        external_customer_id: quote.user_id, // L'ID utilisateur de notre système
+        currency: 'EUR',
+        fees: [
+          {
+            item: {
+              invoiceable_type: 'subscription',
+              invoice_display_name: 'Frais initiaux de projet',
+              amount_cents: priceInCents,
+              unit_amount_cents: priceInCents,
+              quantity: 1
+            },
+          },
+        ],
+      },
+    });
+
+    // 4. Mettre à jour le statut du devis dans notre base de données
+    const { error: updateError } = await supabase
+      .from('quotes')
+      .update({
+        status: 'onboarding_en_cours',
+        docuseal_document_id: docusealResponse.id.toString(),
+      })
+      .eq('id', quoteId);
+
+    if (updateError) {
+      throw updateError;
+    }
+
+    revalidatePath('/admin');
+    return { success: true, message: "Processus d'onboarding lancé avec succès." };
+
+  } catch (error: any) {
+    console.error("Erreur lors du lancement de l'onboarding:", error);
+    return { success: false, error: `Une erreur est survenue: ${error.message}` };
+  }
+}
+
+/**
+ * Action serveur pour rejeter un devis.
+ */
+export async function rejectQuoteAction(quoteId: number) {
+  if (!quoteId) {
+    return { success: false, error: 'ID du devis manquant.' };
+  }
+
+  const cookieStore = cookies();
+  const supabase = createServer(cookieStore);
+
+  try {
+    const { error } = await supabase
+      .from('quotes')
+      .update({ status: 'rejeté' })
+      .eq('id', quoteId);
+
+    if (error) {
+      throw error;
+    }
+
+    revalidatePath('/admin');
+    return { success: true, message: 'Devis rejeté avec succès.' };
+  } catch (error: any) {
+    console.error('Erreur lors du rejet du devis:', error);
+    return { success: false, error: `Une erreur est survenue: ${error.message}` };
   }
 }


### PR DESCRIPTION
This commit introduces the server-side logic for managing new quotes from the Admin Dashboard.

- Adds two new server actions, `onboardQuoteAction` and `rejectQuoteAction`.
- `onboardQuoteAction` initiates the client onboarding process by sending a contract via DocuSeal, creating an invoice in Lago, and updating the quote status.
- `rejectQuoteAction` updates the quote status to 'rejeté'.
- Refactors the `QuoteList` component to use these new server actions, providing a form to set the price for onboarding and a button for rejection.
- The UI now provides feedback during action processing using `useTransition` and `SubmitButton`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Reject Quote action with confirmation feedback.
  * Onboarding now accepts a price input in euros and provides clearer success/error toasts.

* **UI/UX**
  * Onboarding form is always visible; no status gating.
  * Separate onboarding form and adjacent reject button for clearer actions.
  * Updated labels: onboarding button shows “Lancement...” when submitting; reject button shows “Rejet...” and disables during processing.
  * Price field now uses placeholder “Prix (€)” with decimal support (step 0.01).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->