### PR TITLE
hotfix(supabase): Update gotrue image version to v2.140.0

### DIFF
--- a/docker/supabase/docker-compose.yml
+++ b/docker/supabase/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
   auth:
     container_name: supabase_auth_automatic
-    image: supabase/gotrue:v2.138.2 # This version might need updating if problematic
+    image: supabase/gotrue:v2.140.0 # This version might need updating if problematic
     restart: unless-stopped
     environment:
       API_EXTERNAL_URL: ${API_EXTERNAL_URL:-http://localhost:8000}


### PR DESCRIPTION
Updates the Docker image for the auth service to supabase/gotrue:v2.140.0. This is a hotfix to address a startup failure caused by an incompatible image tag in the previous version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded authentication service to Supabase GoTrue v2.140.0.
  * Aligns the stack with the latest upstream release for improved compatibility.
  * No configuration changes required; existing sign-in and sign-up flows remain supported.
  * Includes routine upstream fixes and enhancements bundled with this version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->